### PR TITLE
PyTorch Template

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "src/models/tf_template"]
 	path = src/models/tf_template
 	url = https://github.com/crequena/earthnet-tf-template.git
+[submodule "src/models/pt_template"]
+	path = src/models/pt_template
+	url = git@github.com:vitusbenson/earthnet-pytorch-template.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,4 +90,5 @@ RUN pip3 install numpy==1.19.2
 RUN pip3 install torch==1.6.0 torchvision==0.7.0 pytorch-lightning==1.1.0
 RUN pip3 install matplotlib==3.3.2 tqdm Pillow shapely opencv-python pandas scikit-learn imgaug imantics scipy scikit-image seaborn pandas
 RUN pip3 install earthnet
+RUN pip3 install segmentation-models-pytorch
 RUN conda install -y ipykernel

--- a/configs/pt_template.yml
+++ b/configs/pt_template.yml
@@ -1,0 +1,16 @@
+---
+# Mapping from run.py into src/models/pt_template submodule
+entry_point:
+    test: src/models/pt_template/test.py
+    train: src/models/pt_template/train.py
+conda_env: ENpt16py38
+
+#argument-to-pt_template_entry.py: argument to run.py
+mapped_args_train:
+    setting: experiment_settings
+mapped_args_test:
+    setting: experiment_settings
+    checkpoint: checkpoint
+    track: split_name
+    pred_dir: out_expr_dir
+...


### PR DESCRIPTION
I added a PyTorch template. The integration is not very neat. Actually i think the training does not work at the moment, or at least the folders that run.py thinks will be used are not going to be used. Actually I dont understand well what all the options of run.py mean thats why I did not proceed further. Maybe you have an idea of what to do so that the two worlds interplay well. I'd like to keep everything required for the training of a PyTorch model inside the respective setting.yaml but also of course it would be nice to have the same "folder magic" run.py uses for the Tensorflow models working for PyTorch. One Issue with that might be that currently i let lightning automatically generate the logging folder (the "version_x"), but this can definitly be dealt with, see: https://pytorch-lightning.readthedocs.io/en/latest/generated/pytorch_lightning.loggers.TensorBoardLogger.html#pytorch_lightning.loggers.TensorBoardLogger . 

While you review I will also try to improve docstrings etc. :)

Closes #7 