### PR TITLE
Always use `https` as the source for submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/crequena/earthnet-tf-template.git
 [submodule "src/models/pt_template"]
 	path = src/models/pt_template
-	url = git@github.com:vitusbenson/earthnet-pytorch-template.git
+	url = https://github.com/crequena/vitusbenson/earthnet-pytorch-template.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/crequena/earthnet-tf-template.git
 [submodule "src/models/pt_template"]
 	path = src/models/pt_template
-	url = https://github.com/crequena/vitusbenson/earthnet-pytorch-template.git
+	url = https://github.com/vitusbenson/earthnet-pytorch-template.git


### PR DESCRIPTION
This PR changes the URL of all submodules in the package to use `https`. Otherwise, there are scenarios that the user has only configured HTTPS access but not SSH access of GitHub. The current implementation may trigger the following error:

```bash
(base) ➜  GitHub git clone --recursive https://github.com/sxjscience/earthnet-model-intercomparison-suite.git --depth 1
Cloning into 'earthnet-model-intercomparison-suite'...
remote: Enumerating objects: 39, done.
remote: Counting objects: 100% (39/39), done.
remote: Compressing objects: 100% (34/34), done.
remote: Total 39 (delta 1), reused 23 (delta 0), pack-reused 0
Receiving objects: 100% (39/39), 1.44 MiB | 3.06 MiB/s, done.
Resolving deltas: 100% (1/1), done.
Submodule 'src/models/pt_template' (https://github.com/crequena/vitusbenson/earthnet-pytorch-template.git) registered for path 'src/models/pt_template'
Submodule 'src/models/tf_template' (https://github.com/crequena/earthnet-tf-template.git) registered for path 'src/models/tf_template'
Cloning into '/Users/.../Documents/GitHub/earthnet-model-intercomparison-suite/src/models/pt_template'...
remote: Not Found
fatal: repository 'https://github.com/crequena/vitusbenson/earthnet-pytorch-template.git/' not found
fatal: clone of 'https://github.com/crequena/vitusbenson/earthnet-pytorch-template.git' into submodule path '/Users/.../Documents/GitHub/earthnet-model-intercomparison-suite/src/models/pt_template' failed
Failed to clone 'src/models/pt_template'. Retry scheduled
Cloning into '/Users/.../Documents/GitHub/earthnet-model-intercomparison-suite/src/models/tf_template'...
remote: Enumerating objects: 1662, done.        
remote: Counting objects: 100% (39/39), done.        
remote: Compressing objects: 100% (26/26), done.        
remote: Total 1662 (delta 13), reused 35 (delta 13), pack-reused 1623        
Receiving objects: 100% (1662/1662), 452.38 KiB | 3.38 MiB/s, done.
Resolving deltas: 100% (1192/1192), done.
Cloning into '/Users/.../Documents/GitHub/earthnet-model-intercomparison-suite/src/models/pt_template'...
remote: Not Found
fatal: repository 'https://github.com/crequena/vitusbenson/earthnet-pytorch-template.git/' not found
fatal: clone of 'https://github.com/crequena/vitusbenson/earthnet-pytorch-template.git' into submodule path '/Users/.../Documents/GitHub/earthnet-model-intercomparison-suite/src/models/pt_template' failed
Failed to clone 'src/models/pt_template' a second time, aborting
```

After the fix, there is no such issue:

```bash
(base) ➜  GitHub git clone --recursive https://github.com/sxjscience/earthnet-model-intercomparison-suite.git --depth 1
Cloning into 'earthnet-model-intercomparison-suite'...
remote: Enumerating objects: 39, done.
remote: Counting objects: 100% (39/39), done.
remote: Compressing objects: 100% (34/34), done.
remote: Total 39 (delta 1), reused 23 (delta 0), pack-reused 0
Receiving objects: 100% (39/39), 1.44 MiB | 7.67 MiB/s, done.
Resolving deltas: 100% (1/1), done.
Submodule 'src/models/pt_template' (https://github.com/vitusbenson/earthnet-pytorch-template.git) registered for path 'src/models/pt_template'
Submodule 'src/models/tf_template' (https://github.com/crequena/earthnet-tf-template.git) registered for path 'src/models/tf_template'
Cloning into '/Users/.../Documents/GitHub/earthnet-model-intercomparison-suite/src/models/pt_template'...
remote: Enumerating objects: 20, done.        
remote: Counting objects: 100% (20/20), done.        
remote: Compressing objects: 100% (15/15), done.        
remote: Total 20 (delta 2), reused 16 (delta 1), pack-reused 0        
Receiving objects: 100% (20/20), 11.76 KiB | 1.17 MiB/s, done.
Resolving deltas: 100% (2/2), done.
Cloning into '/Users/.../Documents/GitHub/earthnet-model-intercomparison-suite/src/models/tf_template'...
remote: Enumerating objects: 1662, done.        
remote: Counting objects: 100% (39/39), done.        
remote: Compressing objects: 100% (26/26), done.        
remote: Total 1662 (delta 13), reused 35 (delta 13), pack-reused 1623        
Receiving objects: 100% (1662/1662), 452.38 KiB | 3.19 MiB/s, done.
Resolving deltas: 100% (1192/1192), done.
Submodule path 'src/models/pt_template': checked out 'd88545fa2b4280e75c59dda90e728823dbc0139b'
Submodule path 'src/models/tf_template': checked out 'b17b8e0f21f59cc3b9b88b9be564a02dbc7b9d9d'

```